### PR TITLE
Make the description display in Clap providers

### DIFF
--- a/autoload/clap/provider/coc_actions.vim
+++ b/autoload/clap/provider/coc_actions.vim
@@ -1,4 +1,5 @@
-" description: code actions of selected range
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the code actions of selected range
 
 let s:actions = {}
 

--- a/autoload/clap/provider/coc_commands.vim
+++ b/autoload/clap/provider/coc_commands.vim
@@ -1,4 +1,5 @@
-" description: registered commands of coc.nvim
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the registered commands of coc.nvim
 
 let s:commands = {}
 

--- a/autoload/clap/provider/coc_diagnostics.vim
+++ b/autoload/clap/provider/coc_diagnostics.vim
@@ -1,4 +1,6 @@
-" description: diagnostics
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the diagnostics
+
 " TODO: Icon
 let s:diagnostics = {}
 

--- a/autoload/clap/provider/coc_extensions.vim
+++ b/autoload/clap/provider/coc_extensions.vim
@@ -1,4 +1,5 @@
-" description: manage coc extensions
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List/manage the coc extensions
 
 let s:extensions = {}
 

--- a/autoload/clap/provider/coc_location.vim
+++ b/autoload/clap/provider/coc_location.vim
@@ -1,4 +1,5 @@
-" TODO: Icon
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the location items
 
 let s:location = {}
 

--- a/autoload/clap/provider/coc_outline.vim
+++ b/autoload/clap/provider/coc_outline.vim
@@ -1,4 +1,5 @@
-" description: symbols of current document
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the symbols of current document
 
 let s:outline = {}
 

--- a/autoload/clap/provider/coc_services.vim
+++ b/autoload/clap/provider/coc_services.vim
@@ -1,4 +1,6 @@
-" description: registered services of coc.nvim
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the registered services of coc.nvim
+
 let s:services = {}
 
 function! s:services.source() abort

--- a/autoload/clap/provider/coc_symbols.vim
+++ b/autoload/clap/provider/coc_symbols.vim
@@ -1,4 +1,6 @@
-" description: search workspace symbols
+" Author: vn-ki@https://github.com/vn-ki
+" Description: List the workspace symbols
+
 let s:symbols = {}
 
 let s:kind_dict = {}


### PR DESCRIPTION
Need https://github.com/liuchengxu/vim-clap/commit/42e1e3d7390765f5581118d8af1dfa42f7e7c00d

Now people can see all the autoloaded providers in `:Clap providers`:

<img width="1126" alt="截屏2020-04-14 上午9 23 23" src="https://user-images.githubusercontent.com/8850248/79175950-9f570900-7e31-11ea-85d7-742c97c63d85.png">

Feel free to change the info of `Author` and `Description` later.
