### PR TITLE
Rewrite coc_extensions

### DIFF
--- a/autoload/clap/provider/coc_extensions.vim
+++ b/autoload/clap/provider/coc_extensions.vim
@@ -32,6 +32,7 @@ function! s:invoke_action(cmd, msg) abort
     let g:clap.display.initial_size = len(refreshed_source)
     call clap#indicator#set_matches_number(len(refreshed_source))
   endif
+  call clap#helper#echo_info('extension '.id.' '.a:msg)
 endfunction
 
 let s:extensions.syntax = 'clap_coc_extensions'

--- a/autoload/clap/provider/coc_extensions.vim
+++ b/autoload/clap/provider/coc_extensions.vim
@@ -39,7 +39,7 @@ let s:extensions.syntax = 'clap_coc_extensions'
 let s:extensions.action = {
       \ '&Uninstall': { -> s:invoke_action('uninstallExtension', 'uninstalled') },
       \ '&Reload': { -> s:invoke_action('reloadExtension', 'reloaded') },
-      \ '&DeactivateExtension': { -> s:invoke_action('deactivateExtension', 'deactivated') },
+      \ '&Deactivate': { -> s:invoke_action('deactivateExtension', 'deactivated') },
       \ '&Toggle': { -> s:invoke_action('toggleExtension', 'toggled') },
       \ }
 let g:clap#provider#coc_extensions# = s:extensions

--- a/autoload/clap/provider/coc_extensions.vim
+++ b/autoload/clap/provider/coc_extensions.vim
@@ -3,65 +3,42 @@
 
 let s:extensions = {}
 
+let s:state_map = {'activated': '*', 'disabled': '-', 'loaded': '+'}
+
+function! s:into_line(extension) abort
+  let state = get(s:state_map, a:extension.state, '?')
+  return state.' '.a:extension.id.' '.a:extension.version.' '.a:extension.root
+endfunction
+
 function! s:extensions.source() abort
-  " TODO: Wait for custom actions
-  let l:exts = CocAction('extensionStats')
-  if !empty(l:exts)
-    return s:get_extensions(l:exts)
-  else
-    return [v:exception]
+  return map(CocAction('extensionStats'), 's:into_line(v:val)')
+endfunction
+
+function! s:extract_id(line) abort
+  return matchstr(a:line, '. \zs\(.*\)\ze \d\+.\d\+.\d\+')
+endfunction
+
+function! s:extensions.sink(selected) abort
+  call CocAction('toggleExtension', s:extract_id(a:selected))
+endfunction
+
+function! s:invoke_action(cmd, msg) abort
+  let id = s:extract_id(g:clap.display.getcurline())
+  call CocAction(a:cmd, id)
+  " Refresh the source list to reflect the changes
+  let refreshed_source = s:extensions.source()
+  call g:clap.display.set_lines(refreshed_source)
+  if a:cmd ==# 'uninstallExtension'
+    let g:clap.display.initial_size = len(refreshed_source)
+    call clap#indicator#set_matches_number(len(refreshed_source))
   endif
-endfunction
-
-function! s:extensions.sink() abort
-
-endfunction
-
-function! s:format_coc_extension(item) abort
-  " state id version root
-  let l:state = '+'
-  if a:item.state == 'activated'
-    let l:state = '*'
-  elseif a:item.state == 'disabled'
-    let l:state = '-'
-  endif
-  return l:state . ' ' . a:item.id . ' ' . a:item.root
-endfunction
-
-function! s:get_extensions(exts) abort
-  let l:exts_activated = filter(copy(a:exts), {key, val -> val.state == 'activated'})
-  let l:exts_loaded = filter(copy(a:exts), {key, val -> val.state == 'loaded'})
-  let l:exts_disabled = filter(copy(a:exts), {key, val -> val.state == 'disabled'})
-  let l:exts = extend(l:exts_activated, l:exts_loaded)
-  let l:exts = extend(l:exts, l:exts_disabled)
-  return map(l:exts, 's:format_coc_extension(v:val)')
-endfunction
-
-function! s:syntax() abort
-  if has('syntax') && exists('g:syntax_on')
-  endif
-endfunction
-
-function! s:extension_handler(ext) abort
-  let l:parsed = s:parse_extension(a:ext[1:])
-  if type(l:parsed) == v:t_dict
-    if l:parsed.state == '*'
-      silent call CocAction('deactivateExtension', l:parsed.id)
-    elseif l:parsed.state == '+'
-      silent call CocAction('activeExtension', l:parsed.id)
-    endif
-    call coc_fzf#extensions#fzf_run(0)
-  endif
-endfunction
-
-function! s:parse_extension(ext) abort
-  let l:match = matchlist(a:ext, '\v^(.)\s(\S*)\s(.*)')[1:4]
-  if empty(l:match) || empty(l:match[0])
-    return
-  endif
-  return ({'state' : l:match[0], 'id' : l:match[1], 'root' : l:match[2]})
 endfunction
 
 let s:extensions.syntax = 'clap_coc_extensions'
-
+let s:extensions.action = {
+      \ '&Uninstall': { -> s:invoke_action('uninstallExtension', 'uninstalled') },
+      \ '&Reload': { -> s:invoke_action('reloadExtension', 'reloaded') },
+      \ '&DeactivateExtension': { -> s:invoke_action('deactivateExtension', 'deactivated') },
+      \ '&Toggle': { -> s:invoke_action('toggleExtension', 'toggled') },
+      \ }
 let g:clap#provider#coc_extensions# = s:extensions


### PR DESCRIPTION
- The `sink` action is `ToggleExtension`.
- Action dialog options:  `Uninstall`, `Reload`, `Deactivate` and `Toggle` extension.

Close https://github.com/vn-ki/coc-clap/issues/4