### PR TITLE
fix to preserve actions

### DIFF
--- a/autoload/clap/provider/coc_actions.vim
+++ b/autoload/clap/provider/coc_actions.vim
@@ -3,15 +3,17 @@
 
 let s:actions = {}
 
+let s:code_actions = []
+
 function! s:actions.source() abort
   let l:bufnr = bufnr('')
 
   execute 'keepalt buffer' g:clap.start.bufnr
-  let l:actions = CocAction('codeActions')
+  let s:code_actions = CocAction('codeActions')
   execute 'keepalt buffer' l:bufnr
 
-  if !empty(l:actions)
-    return s:get_actions(l:actions)
+  if !empty(s:code_actions)
+    return s:get_actions(s:code_actions)
   else
     return [v:exception]
   endif
@@ -20,7 +22,7 @@ endfunction
 function! s:actions.sink(curline) abort
   let l:index = s:parse_action(a:curline)
   if type(l:index) == v:t_number
-    call CocAction('doCodeAction', g:coc_fzf_actions[l:index])
+    call CocAction('doCodeAction', s:code_actions[l:index])
   endif
 endfunction
 


### PR DESCRIPTION
This PR fixes an error that occurs when executing code action's sink function.

- Before
![Kapture 2020-05-11 at 22 36 00](https://user-images.githubusercontent.com/6854255/81567811-d3ddc680-93d7-11ea-8fb8-d1e739c27fff.gif)

- After
![Kapture 2020-05-11 at 22 32 07](https://user-images.githubusercontent.com/6854255/81567598-7cd7f180-93d7-11ea-849e-2b153da23ed0.gif)
