### PR TITLE
Fix cursor behavior in coc_outline and coc_actions

### DIFF
--- a/autoload/clap/provider/coc_actions.vim
+++ b/autoload/clap/provider/coc_actions.vim
@@ -6,11 +6,12 @@ let s:actions = {}
 let s:code_actions = []
 
 function! s:actions.source() abort
-  let l:bufnr = bufnr('')
+  let l:bufnr = g:clap.start.bufnr
+  if empty(bufname(l:bufnr))
+    return ['buffer name is empty']
+  endif
 
-  execute 'keepalt buffer' g:clap.start.bufnr
-  let s:code_actions = CocAction('codeActions')
-  execute 'keepalt buffer' l:bufnr
+  let s:code_actions = CocAction('codeActions', l:bufnr)
 
   if !empty(s:code_actions)
     return s:get_actions(s:code_actions)

--- a/autoload/clap/provider/coc_outline.vim
+++ b/autoload/clap/provider/coc_outline.vim
@@ -4,13 +4,7 @@
 let s:outline = {}
 
 function! s:outline.source() abort
-  let l:bufnr = bufnr('')
-
-  execute 'keepalt buffer' g:clap.start.bufnr
-  let l:outline = s:get_outline()
-  execute 'keepalt buffer' l:bufnr
-
-  return l:outline
+  return s:get_outline()
 endfunction
 
 function! s:outline.sink(curline) abort
@@ -48,7 +42,12 @@ function! s:format_coc_outline_docsym(item) abort
 endfunction
 
 function! s:get_outline() abort
-  let l:symbols = CocAction('documentSymbols')
+  let l:bufnr = g:clap.start.bufnr
+  if empty(bufname(l:bufnr))
+    return ['buffer name is empty']
+  endif
+
+  let l:symbols = CocAction('documentSymbols', l:bufnr)
   if type(l:symbols) != v:t_list
     " ctags: try force language to filtetype
     let l:ctags_base_cmd = 'set -o pipefail && ctags -f - --excmd=number'


### PR DESCRIPTION
Close #14 

As I understand it, `execute 'keepalt buffer' g:clap.start.bufnr` causes the issue #14 .
I don't know how this happen.
But, I think it is better to show error message instead of doing `execute 'keepalt buffer' g:clap.start.bufnr` when buffer name is empty (no file is open).
`coc_outline` and `coc_actions` requires a file.