### PR TITLE
Make full use of the preview window by using clap#preview#get_range()

### DIFF
--- a/autoload/coc_clap.vim
+++ b/autoload/coc_clap.vim
@@ -1,5 +1,5 @@
 function! coc_clap#highlight_preview(fpath, lnum) abort
-  let [start, end, hi_lnum] = clap#preview#get_line_range(a:lnum, 5)
+  let [start, end, hi_lnum] = clap#preview#get_range(a:lnum)
   let lines = readfile(expand(a:fpath), '')
   let preview_lines = lines[start : end]
   call insert(preview_lines, a:fpath)


### PR DESCRIPTION
Instead of using the fixed preview size, use the new API to get the preview size that can fill the whole preview window.